### PR TITLE
Cleanup component

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Angular Dart Snippets Generator.
 
 ### Generating Dart Codes
 
-adcomp - Generate Angular Component
+ad-comp - Generate Angular Component
 
 ### Template Syntax
 
@@ -19,7 +19,7 @@ ad-if - Angular Dart If Directive
 ad-for - Angular Dart For Loop Directive  
 ad-for-li - Angular Dart For Loop Directive with li Element  
 ad-for-index - Angular Dart For Loop Directive with Index  
-ad-click - Angular Dart Click Event  
+ad-click - Angular Dart Click Event
 
 ## Requirements
 
@@ -27,8 +27,6 @@ VSCode
 Dart Extension
 
 ## Known Issues
-
-
 
 ## Release Notes
 
@@ -52,19 +50,19 @@ Bug Fixes
 
 HTML Template Support
 
------------------------------------------------------------------------------------------------------------
+---
 
 ## Working with Markdown
 
-**Note:** You can author your README using Visual Studio Code.  Here are some useful editor keyboard shortcuts:
+**Note:** You can author your README using Visual Studio Code. Here are some useful editor keyboard shortcuts:
 
-* Split the editor (`Cmd+\` on macOS or `Ctrl+\` on Windows and Linux)
-* Toggle preview (`Shift+CMD+V` on macOS or `Shift+Ctrl+V` on Windows and Linux)
-* Press `Ctrl+Space` (Windows, Linux) or `Cmd+Space` (macOS) to see a list of Markdown snippets
+- Split the editor (`Cmd+\` on macOS or `Ctrl+\` on Windows and Linux)
+- Toggle preview (`Shift+CMD+V` on macOS or `Shift+Ctrl+V` on Windows and Linux)
+- Press `Ctrl+Space` (Windows, Linux) or `Cmd+Space` (macOS) to see a list of Markdown snippets
 
 ### For more information
 
-* [Visual Studio Code's Markdown Support](http://code.visualstudio.com/docs/languages/markdown)
-* [Markdown Syntax Reference](https://help.github.com/articles/markdown-basics/)
+- [Visual Studio Code's Markdown Support](http://code.visualstudio.com/docs/languages/markdown)
+- [Markdown Syntax Reference](https://help.github.com/articles/markdown-basics/)
 
 **Enjoy!**

--- a/snippets/dart-snippets.code-snippets
+++ b/snippets/dart-snippets.code-snippets
@@ -1,21 +1,16 @@
 {
     "ComponentSnippet": {
-        "prefix": "adcomp",
+        "prefix": "ad-comp",
         "body": [
-            "import 'package:angular/angular.dart';\n\n",
+            "import 'package:angular/angular.dart';\n",
             "@Component(",
-            "\tselector: '$1',",
-            "\ttemplateUrl: './$1_component.html',",
-            "\tstyleUrls: ['./$1_component.css'],",
+            "\tselector: '${1:component-selector}',",
+            "\ttemplateUrl: '${2:component_path}.html',",
+            "\tstyleUrls: ['${2:component_path}.css'],",
             "\tdirectives: [coreDirectives],",
             "\tproviders: [],",
-            ")\n\n",
-            "class ${2:Name}Component implements OnInit {",
-            "\t@override",
-            "\tvoid ngOnInit() {",
-            "\t\t// TODO: implement ngOnInit",
-            "\t\t$3",
-            "\t}",
+            ")",
+            "class ${3:Name}Component {",
             "}",
         ]
     }


### PR DESCRIPTION
Rename `adcomp` to `ad-comp` to match other snippets

Correctly format generated code (no additional return to line)

Respect AngularDart and Dart convention for naming (component selector, file path)

Remove OnInit, which is not something every component should always implements